### PR TITLE
Hide address bar

### DIFF
--- a/JBWebViewController/JBWebViewController.h
+++ b/JBWebViewController/JBWebViewController.h
@@ -24,6 +24,9 @@ typedef void (^completion)(JBWebViewController *controller);
 // Loding string
 @property (nonatomic, strong) NSString *loadingString;
 
+// hide address bar
+@property (nonatomic, assign) BOOL hideAddressBar;
+
 // Public header methods
 - (id)initWithUrl:(NSURL *)url;
 - (void)show;

--- a/JBWebViewController/JBWebViewController.m
+++ b/JBWebViewController/JBWebViewController.m
@@ -148,6 +148,13 @@
 
 #pragma mark - "Showing controller"
 
+-(void)setHideAddressBar:(BOOL)hideAdressBar {
+    _hideAddressBar = hideAdressBar;
+    
+    self.subtitleLabel.hidden = hideAdressBar;
+    [self adjustNavigationbar];
+}
+
 - (void)show {
     // Showing controller with no completion void
     [self showControllerWithCompletion:nil];
@@ -253,8 +260,13 @@
     }
     
     // Setting frames on title & subtitle labels
-    [_titleLabel setFrame:CGRectMake(_titleLabel.frame.origin.x, _titleLabel.frame.origin.y, MIN(_titleLabel.frame.size.width, self.view.frame.size.width - buttonsWidth), _titleLabel.frame.size.height)];
+    if (_hideAddressBar) {
+        [_titleLabel setFrame:CGRectMake(_titleLabel.frame.origin.x, _titleView.frame.size.height/2-_titleLabel.frame.size.height/2, MIN(_titleLabel.frame.size.width, self.view.frame.size.width - buttonsWidth), _titleLabel.frame.size.height)];
+    } else {
+        [_titleLabel setFrame:CGRectMake(_titleLabel.frame.origin.x, _titleLabel.frame.origin.y, MIN(_titleLabel.frame.size.width, self.view.frame.size.width - buttonsWidth), _titleLabel.frame.size.height)];
+    }
     [_subtitleLabel setFrame:CGRectMake(_subtitleLabel.frame.origin.x, _subtitleLabel.frame.origin.y, MIN(_subtitleLabel.frame.size.width, self.view.frame.size.width - buttonsWidth), _subtitleLabel.frame.size.height)];
+    
 }
 
 - (void)addNavigationButtonsButtons {


### PR DESCRIPTION
Added a feature to hide the address bar.

```
    // Method for showing controller with completion block
    controller.hideAddressBar = YES; //hides the address bar
    [controller showControllerWithCompletion:^(JBWebViewController *controller) {
        // Completion typedef block
        NSLog(@"Controller has arrived.");
    }];
```

I need this in a project where I want to show terms and conditions pages. In this case it is useful to hide the address.