### PR TITLE
Webview made available public

### DIFF
--- a/JBWebViewController/JBWebViewController.h
+++ b/JBWebViewController/JBWebViewController.h
@@ -24,6 +24,9 @@ typedef void (^completion)(JBWebViewController *controller);
 // Loding string
 @property (nonatomic, strong) NSString *loadingString;
 
+// Public variables
+@property (nonatomic, strong) UIWebView *webView;
+
 // Public header methods
 - (id)initWithUrl:(NSURL *)url;
 - (void)show;

--- a/JBWebViewController/JBWebViewController.m
+++ b/JBWebViewController/JBWebViewController.m
@@ -14,7 +14,6 @@
     @property (nonatomic, strong) NSURL *url;
     @property (nonatomic) BOOL hasExtraButtons;
     @property (nonatomic, strong) UIView *titleView;
-    @property (nonatomic, strong) UIWebView *webView;
     @property (nonatomic, strong) UILabel *titleLabel;
     @property (nonatomic, strong) UILabel *subtitleLabel;
     @property (nonatomic, strong) NJKWebViewProgress *progressProxy;


### PR DESCRIPTION
To subclass ```JBWebViewController``` and to add some custom business logic to ```webview``` events, having ```webview``` available publicly was the best alternative. After this, a subclass can listen ```webViewDidFinishLoad``` and inject some CSS, run some JS etc.