### PR TITLE
Added awakeFromNib so the controller can be added via storyboards.

### DIFF
--- a/JBWebViewController/JBWebViewController.m
+++ b/JBWebViewController/JBWebViewController.m
@@ -35,6 +35,10 @@
     return self;
 }
 
+- (void)awakeFromNib {
+    [self setup];
+}
+
 - (void)viewDidLoad {
     // Standard super class stuff
     [super viewDidLoad];


### PR DESCRIPTION
In order to be able to use the JBWebViewController from within a storyboard, for example via a segue, setup needs to be called from awakeFromNib. This PR takes care of this and fixes #13 